### PR TITLE
Solving constraint error in fm_to_pysat.py

### DIFF
--- a/famapy/metamodels/pysat_metamodel/transformations/fm_to_pysat.py
+++ b/famapy/metamodels/pysat_metamodel/transformations/fm_to_pysat.py
@@ -90,10 +90,10 @@ class FmToPysat(ModelToModel):
         dest = self.destination_model.variables.get(ctc.destination.name)
         orig = self.destination_model.variables.get(ctc.origin.name)
         if ctc.ctc_type == 'requires':
-            self.cnf.append([orig, dest])
+            self.cnf.append([-1*orig, dest])
 
         elif ctc.ctc_type == 'excludes':
-            self.cnf.append([orig, -1*dest])
+            self.cnf.append([-1*orig, -1*dest])
 
     def transform(self):
         for feature in self.source_model.get_features():


### PR DESCRIPTION
I found an error in excludes and requires constraints that should be like:
Requires: [-1 x orig, dest] (A->B) For Glucose3 this represent that the solution with [A,-B] (A&¬B) could never happen.
Excludes: [-1 x orig, -1 x dest] (A<->B) For Glucose3 this represent that the solution with [A,B] (A&B) could never happen.