### PR TITLE
Solving issue #35

### DIFF
--- a/famapy/metamodels/pysat_metamodel/models/pysat_model.py
+++ b/famapy/metamodels/pysat_metamodel/models/pysat_model.py
@@ -12,16 +12,19 @@ class PySATModel(VariabilityModel):
         return 'pysat'
 
     def __init__(self) -> None:
-        self.r_cnf = CNF()
-        self.ctc_cnf = CNF()
-        self.variables: dict[str, Any] = {}
-        self.features: dict[str, Any] = {}
+        #self.r_cnf = CNF()  # ToDo: This should be avoid
+        #self.ctc_cnf = CNF()  # ToDo: This should be avoid
+        self._cnf = CNF()
+        self.variables: dict[str, int] = {}  # feature's name -> id
+        self.features: dict[int, str] = {}  # id -> feature's name
 
     def add_clause(self, clause: list[int]) -> None:
-        self.ctc_cnf.append(clause)
+        #self.ctc_cnf.append(clause)
+        self._cnf.append(clause)
 
     def get_all_clauses(self) -> CNF:
-        clauses = CNF()
-        clauses.extend(self.r_cnf.clauses)
-        clauses.extend(self.ctc_cnf.clauses)
-        return clauses
+        #clauses = CNF()
+        #clauses.extend(self.r_cnf.clauses)
+        #clauses.extend(self.ctc_cnf.clauses)
+        #return clauses
+        return self._cnf

--- a/famapy/metamodels/pysat_metamodel/models/txtcnf_model.py
+++ b/famapy/metamodels/pysat_metamodel/models/txtcnf_model.py
@@ -1,0 +1,210 @@
+from typing import Optional
+from enum import Enum, auto
+
+
+class CNFLogicConnective(Enum):
+    """The propositional logic connectives a formula in CNF can contain."""
+    NOT = auto()
+    AND = auto()
+    OR = auto()
+
+
+class TextCNFNotation(Enum):
+    """Possible notations of a CNF formula. 
+
+    Five different notations are available:
+        Logical symbols:
+            (A) ∧ (¬B ∨ C) ∧ ...
+        Textual symbols:
+            (A) and (not B or C) and ...
+        Java symbols:
+            (A) && (!B || C) && ...
+        Java Short symbols:
+            (A) & (!B | C) && ...
+        Short symbols:
+            (A) & (-B | C) & ...
+    """
+    LOGICAL = {CNFLogicConnective.NOT: '¬', 
+               CNFLogicConnective.AND: '∧', 
+               CNFLogicConnective.OR: '∨'}
+    TEXTUAL = {CNFLogicConnective.NOT: 'not', 
+               CNFLogicConnective.AND: 'and', 
+               CNFLogicConnective.OR: 'or'}
+    JAVA = {CNFLogicConnective.NOT: '!', 
+            CNFLogicConnective.AND: '&&', 
+            CNFLogicConnective.OR: '||'}
+    JAVA_SHORT = {CNFLogicConnective.NOT: '!', 
+                  CNFLogicConnective.AND: '&', 
+                  CNFLogicConnective.OR: '|'}
+    SHORT = {CNFLogicConnective.NOT: '-', 
+             CNFLogicConnective.AND: '&', 
+             CNFLogicConnective.OR: '|'}
+
+
+class TextCNFModel():
+    """Textual representation of a conjunctive normal form (CNF) formula.
+
+    A CNF formula (or clausal normal form) is a conjunction of one or more clauses, 
+    where a clause is a disjunction of literals.
+    """
+
+    def __init__(self) -> None:
+        self._cnf_formula: Optional[str] = None
+        self._cnf_notation: Optional[TextCNFNotation] = None
+        self._variables: list[str] = []  # list of str with variables' names
+
+    def from_textual_cnf(self, cnf_formula: str) -> None:
+        self._cnf_formula = cnf_formula
+        self._cnf_notation = identify_notation(cnf_formula)
+        self._variables = extract_variables(cnf_formula)
+
+    def from_textual_cnf_file(self, filepath: str) -> None:
+        """This method reads any of the available textual notations, 
+        but only one notation at the same time,
+        so the .txt file should include only one of the possible notations in a single line.
+        """
+        with open(filepath, 'r', encoding='utf-8') as file:
+            self.from_textual_cnf(file.readline())
+
+    def write_textual_cnf_file(self, filepath: str, 
+                               syntax: TextCNFNotation = TextCNFNotation.JAVA_SHORT) -> None:
+        """Write the textual CNF formula as a string in a file. 
+
+        Default syntax is TextCNFNotation.JAVA_SHORT: (A) & (!B | C) && ...
+        """
+        cnf_formula = self.get_textual_cnf_formula(syntax)
+        with open(filepath, 'w+', encoding='utf-8') as file:
+            file.write(cnf_formula)
+
+    def get_textual_cnf_notation(self) -> TextCNFNotation:
+        """Return the notation used for the CNF formula."""
+        if self._cnf_formula is None:
+            raise Exception("CNF Model not initialized. Use a `from_` method first.") 
+        assert self._cnf_notation is not None
+        return self._cnf_notation
+
+    def get_textual_cnf_formula(self, 
+                                syntax: Optional[TextCNFNotation] = None) -> str:
+        """Return the CNF formula in the specified notation syntax.
+
+        Default syntax is TextCNFNotation.JAVA_SHORT: (A) & (!B | C) && ...
+        """
+        if self._cnf_formula is None:
+            raise Exception("CNF Model not initialized. Use a `from_` method first.") 
+        assert self._cnf_notation is not None 
+
+        cnf_formula = self._cnf_formula
+        cnf_notation = self._cnf_notation
+
+        if syntax is not None and syntax == cnf_notation:
+            return cnf_formula
+
+        # Translate AND operators
+        symbol_pattern = ' ' + cnf_notation.value[CNFLogicConnective.AND] + ' '
+        new_symbol = ' ' + syntax.value[CNFLogicConnective.AND] + ' '
+        cnf_formula = cnf_formula.replace(symbol_pattern, new_symbol)
+
+        # Translate OR operators
+        symbol_pattern = ' ' + cnf_notation.value[CNFLogicConnective.OR] + ' '
+        new_symbol = ' ' + syntax.value[CNFLogicConnective.OR] + ' '
+        cnf_formula = cnf_formula.replace(symbol_pattern, new_symbol)
+
+        # Translate NOT operators 
+        # This is more complex because the symbol may be part of a feature's name
+        if cnf_notation == TextCNFNotation.TEXTUAL:
+            symbol_pattern = cnf_notation.value[CNFLogicConnective.NOT] + ' '
+            new_symbol = syntax.value[CNFLogicConnective.NOT]
+            cnf_formula = cnf_formula.replace(symbol_pattern, new_symbol)
+        elif syntax == TextCNFNotation.TEXTUAL:
+            symbol_pattern = ' ' + cnf_notation.value[CNFLogicConnective.NOT]
+            new_symbol = ' ' + syntax.value[CNFLogicConnective.NOT] + ' '
+            cnf_formula = cnf_formula.replace(symbol_pattern, new_symbol)
+
+            symbol_pattern = '(' + cnf_notation.value[CNFLogicConnective.NOT]
+            new_symbol = '(' + syntax.value[CNFLogicConnective.NOT] + ' '
+            cnf_formula = cnf_formula.replace(symbol_pattern, new_symbol)
+        else:
+            symbol_pattern = ' ' + cnf_notation.value[CNFLogicConnective.NOT]
+            new_symbol = ' ' + syntax.value[CNFLogicConnective.NOT]
+            cnf_formula = cnf_formula.replace(symbol_pattern, new_symbol)
+
+            symbol_pattern = '(' + cnf_notation.value[CNFLogicConnective.NOT]
+            new_symbol = '(' + syntax.value[CNFLogicConnective.NOT]
+            cnf_formula = cnf_formula.replace(symbol_pattern, new_symbol)
+        return cnf_formula
+
+    def get_variables(self) -> list[str]:
+        """Return the list of variables' names in the CNF formula."""
+        if self._cnf_formula is None:
+            raise Exception("CNF Model not initialized. Use a `from_` method first.") 
+        return self._variables
+
+
+def identify_notation(cnf_formula: str) -> TextCNFNotation:
+    """Return the notation used by the given CNF formula.
+
+    Default TextCNFNotation.JAVA.
+    """
+    notation = check_unary_connective(cnf_formula)
+    if notation is None or notation in (TextCNFNotation.JAVA, TextCNFNotation.JAVA_SHORT):
+        notation = check_binary_connective(cnf_formula)
+    if notation is None:
+        notation = TextCNFNotation.JAVA_SHORT 
+    return notation
+
+
+def check_unary_connective(cnf_formula: str) -> Optional[TextCNFNotation]:
+    symbol = TextCNFNotation.LOGICAL.value[CNFLogicConnective.NOT]
+    if ' ' + symbol in cnf_formula or '(' + symbol in cnf_formula:
+        return TextCNFNotation.LOGICAL
+
+    symbol = TextCNFNotation.SHORT.value[CNFLogicConnective.NOT]
+    if ' ' + symbol in cnf_formula or '(' + symbol in cnf_formula:
+        return TextCNFNotation.SHORT
+
+    symbol = TextCNFNotation.TEXTUAL.value[CNFLogicConnective.NOT]
+    if ' ' + symbol + ' ' in cnf_formula or '(' + symbol + ' ' in cnf_formula:
+        return TextCNFNotation.TEXTUAL
+
+    symbol = TextCNFNotation.JAVA.value[CNFLogicConnective.NOT]  # JAVA or JAVA_SHORT
+    if ' ' + symbol in cnf_formula or '(' + symbol in cnf_formula:
+        return TextCNFNotation.JAVA 
+
+    return None
+
+
+def check_binary_connective(cnf_formula: str) -> Optional[TextCNFNotation]:
+    for notation in TextCNFNotation:
+        for connective in notation.value.keys():
+            if connective != CNFLogicConnective.NOT:
+                symbol = notation.value[connective]
+                symbol_pattern = ' ' + symbol + ' '
+                if symbol_pattern in cnf_formula:
+                    return notation
+    return None
+
+
+def extract_variables(cnf_formula: str) -> list[str]:
+    """Return the list of variables' names of the CNF formula."""
+    variables = set()
+    cnf_notation = identify_notation(cnf_formula)
+
+    # Remove initial and final parenthesis
+    and_symbol_pattern = ' ' + cnf_notation.value[CNFLogicConnective.AND] + ' '
+    clauses = list(map(lambda c: c[1:len(c) - 1], cnf_formula.split(and_symbol_pattern)))
+
+    # Remove final parenthesis of last clause (because of the possible end of line: '\n')
+    if ')' in clauses[len(clauses) - 1]:
+        clauses[len(clauses) - 1] = clauses[len(clauses) - 1][:-1]  
+
+    for clause in clauses:
+        tokens = clause.split(' ')
+        tokens = list(filter(lambda t: t != cnf_notation.value[CNFLogicConnective.OR], tokens))
+        for feature in tokens:
+            if feature == cnf_notation.value[CNFLogicConnective.NOT]:
+                continue
+            if feature.startswith(cnf_notation.value[CNFLogicConnective.NOT]):
+                variables.add(feature.replace(cnf_notation.value[CNFLogicConnective.NOT], '', 1))
+            else:
+                variables.add(feature)
+    return list(variables)

--- a/famapy/metamodels/pysat_metamodel/operations/glucose3_false_optional_features.py
+++ b/famapy/metamodels/pysat_metamodel/operations/glucose3_false_optional_features.py
@@ -25,15 +25,15 @@ class Glucose3FalseOptionalFeatures(FalseOptionalFeatures):
 
 
 def get_false_optional_features(sat_model: PySATModel, feature_model: FeatureModel) -> list[Any]:
-    variant_features = [f for f in feature_model.get_features() 
-                          if not f.is_root() and not f.is_mandatory()]
+    real_optional_features = [f for f in feature_model.get_features() 
+                                if not f.is_root() and not f.is_mandatory()]
 
     result = []
     solver = Glucose3()
     for clause in sat_model.get_all_clauses():
         solver.add_clause(clause)
     
-    for feature in variant_features:
+    for feature in real_optional_features:
         variable = sat_model.variables.get(feature.name)
         parent_variable = sat_model.variables.get(feature.get_parent().name)
         assert variable is not None

--- a/famapy/metamodels/pysat_metamodel/operations/glucose3_false_optional_features.py
+++ b/famapy/metamodels/pysat_metamodel/operations/glucose3_false_optional_features.py
@@ -8,35 +8,32 @@ from famapy.metamodels.pysat_metamodel.models.pysat_model import PySATModel
 
 class Glucose3FalseOptionalFeatures(FalseOptionalFeatures):
 
-    def __init__(self) -> None:
-        self.false_optional_features: list[list[Any]] = []
-
-    def get_false_optional_features(self) -> list[list[Any]]:
-        return self.false_optional_features
-
-    def get_result(self) -> list[list[Any]]:
-        return self.get_false_optional_features()
+    def __init__(self, optional_features: list[str]) -> None:
+        self.result: list[Any] = []
+        self.optional_features = optional_features
 
     def execute(self, model: PySATModel) -> 'Glucose3FalseOptionalFeatures':
-        glucose_r = Glucose3()
-        glucose_r_ctc = Glucose3()
-        for clause in model.r_cnf:
-            glucose_r.add_clause(clause)
-            glucose_r_ctc.add_clause(clause)
-        for clause in model.ctc_cnf:
-            glucose_r_ctc.add_clause(clause)
-
-        if glucose_r_ctc.solve():
-            assumption = 1
-            for feat in model.features:
-                if (
-                    not glucose_r_ctc.solve(assumptions=[-feat]) and
-                    glucose_r.solve(assumptions=[-feat])
-                ):
-                    if glucose_r.solve(assumptions=[assumption, -feat]):
-                        self.false_optional_features.append(model.features.get(feat))
-                    assumption = feat
-
-        glucose_r.delete()
-        glucose_r_ctc.delete()
+        self.result = get_false_optional_features(model, self.optional_features)
         return self
+
+    def get_false_optional_features(self) -> list[list[Any]]:
+        return self.get_result()
+
+    def get_result(self) -> list[Any]:
+        return self.result
+
+
+def get_false_optional_features(model: PySATModel, optional_features: list[str]) -> list[Any]:
+    result = []
+    solver = Glucose3()
+    for clause in model.get_all_clauses():
+        solver.add_clause(clause)
+    
+    for feature in optional_features:
+        variable = model.variables.get(feature)
+        assert variable is not None
+        satisfiable = solver.solve(assumptions=[-variable])
+        if not satisfiable:
+            result.append(feature)
+    solver.delete()
+    return result

--- a/famapy/metamodels/pysat_metamodel/transformations/cnf_to_pysat.py
+++ b/famapy/metamodels/pysat_metamodel/transformations/cnf_to_pysat.py
@@ -1,31 +1,11 @@
-from enum import Enum, auto
-
 from famapy.core.transformations import TextToModel
 
 from famapy.metamodels.pysat_metamodel.models.pysat_model import PySATModel
-
-
-class LogicOperator(Enum):
-    NOT = auto()
-    AND = auto()
-    OR = auto()
-
-
-class CNFNotation(Enum):
-    LOGICAL = {LogicOperator.NOT: '¬', LogicOperator.AND: '∧', LogicOperator.OR: '∨'}
-    JAVA = {LogicOperator.NOT: '!', LogicOperator.AND: '&&', LogicOperator.OR: '||'}
-    SHORT = {LogicOperator.NOT: '-', LogicOperator.AND: '&', LogicOperator.OR: '|'}
-    TEXTUAL = {LogicOperator.NOT: 'not', LogicOperator.AND: 'and', LogicOperator.OR: 'or'}
-
-
-def identify_notation(cnf_formula: str) -> CNFNotation:
-    for notation in CNFNotation:
-        for symbol in notation.value.values():
-            symbol_pattern = ' ' + symbol + ' '
-            if symbol_pattern in cnf_formula:
-                return notation
-    raise Exception("This should have happend. \
-            The CNF file is corrupted or does not adhere to the format")
+from famapy.metamodels.pysat_metamodel.models.txtcnf_model import (
+    TextCNFModel, 
+    TextCNFNotation, 
+    CNFLogicConnective
+)
 
 
 class CNFReader(TextToModel):
@@ -55,10 +35,14 @@ class CNFReader(TextToModel):
         self._path = path
         self.counter = 1
         self.destination_model = PySATModel()
-        self.cnf = self.destination_model.cnf
 
     def transform(self) -> PySATModel:
-        self._read_clauses()
+        cnf_model = TextCNFModel()
+        cnf_model.from_textual_cnf_file(self._path)
+        cnf_notation = cnf_model.get_textual_cnf_notation()
+        cnf_formula = cnf_model.get_textual_cnf_formula(cnf_notation)
+
+        self._extract_clauses(cnf_formula, cnf_notation)
         return self.destination_model
 
     def _add_feature(self, feature_name: str) -> None:
@@ -67,17 +51,8 @@ class CNFReader(TextToModel):
             self.destination_model.features[self.counter] = feature_name
             self.counter += 1
 
-    def _read_cnf_formula(self) -> str:
-        """It assumes the CNF formula is defined in one line in the file."""
-        with open(self._path, encoding='utf-8') as file:
-            cnf_formula = file.readline()
-        return cnf_formula
-
-    def _read_clauses(self) -> None:
-        cnf_formula = self._read_cnf_formula()
-        cnf_notation = identify_notation(cnf_formula)
-
-        and_symbol_pattern = ' ' + cnf_notation.value[LogicOperator.AND] + ' '
+    def _extract_clauses(self, cnf_formula: str, cnf_notation: TextCNFNotation) -> None:
+        and_symbol_pattern = ' ' + cnf_notation.value[CNFLogicConnective.AND] + ' '
         clauses = list(map(lambda c: c[1:len(c) - 1], cnf_formula.split(and_symbol_pattern)))
         # Remove initial and final parenthesis
 
@@ -87,14 +62,14 @@ class CNFReader(TextToModel):
 
         for _c in clauses:
             tokens = _c.split(' ')
-            tokens = list(filter(lambda t: t != cnf_notation.value[LogicOperator.OR], tokens))
+            tokens = list(filter(lambda t: t != cnf_notation.value[CNFLogicConnective.OR], tokens))
             logic_not = False
             cnf_clause = []
             for feature in tokens:
-                if feature == cnf_notation.value[LogicOperator.NOT]:
+                if feature == cnf_notation.value[CNFLogicConnective.NOT]:
                     logic_not = True
-                elif feature.startswith(cnf_notation.value[LogicOperator.NOT]):
-                    feature = feature.replace(cnf_notation.value[LogicOperator.NOT], '', 1)
+                elif feature.startswith(cnf_notation.value[CNFLogicConnective.NOT]):
+                    feature = feature.replace(cnf_notation.value[CNFLogicConnective.NOT], '', 1)
                     self._add_feature(feature)
                     cnf_clause.append(-1 * self.destination_model.variables[feature])
                 else:
@@ -106,42 +81,42 @@ class CNFReader(TextToModel):
                     logic_not = False
             self.destination_model.add_clause(cnf_clause)
 
-    def get_cnf_formula(self, cnf_output_syntax: CNFNotation = CNFNotation.JAVA) -> str:
-        cnf_formula = self._read_cnf_formula()
-        cnf_notation = identify_notation(cnf_formula)
+    # def get_cnf_formula(self, cnf_output_syntax: TextCNFNotation = TextCNFNotation.JAVA) -> str:
+    #     cnf_formula = self._read_cnf_formula()
+    #     cnf_notation = identify_notation(cnf_formula)
 
-        if cnf_output_syntax == cnf_notation:
-            return cnf_formula
-        # Translate AND operators
-        symbol_pattern = ' ' + cnf_notation.value[LogicOperator.AND] + ' '
-        new_symbol = ' ' + cnf_output_syntax.value[LogicOperator.AND] + ' '
-        cnf_formula = cnf_formula.replace(symbol_pattern, new_symbol)
+    #     if cnf_output_syntax == cnf_notation:
+    #         return cnf_formula
+    #     # Translate AND operators
+    #     symbol_pattern = ' ' + cnf_notation.value[CNFLogicConnective.AND] + ' '
+    #     new_symbol = ' ' + cnf_output_syntax.value[CNFLogicConnective.AND] + ' '
+    #     cnf_formula = cnf_formula.replace(symbol_pattern, new_symbol)
 
-        # Translate OR operators
-        symbol_pattern = ' ' + cnf_notation.value[LogicOperator.OR] + ' '
-        new_symbol = ' ' + cnf_output_syntax.value[LogicOperator.OR] + ' '
-        cnf_formula = cnf_formula.replace(symbol_pattern, new_symbol)
+    #     # Translate OR operators
+    #     symbol_pattern = ' ' + cnf_notation.value[CNFLogicConnective.OR] + ' '
+    #     new_symbol = ' ' + cnf_output_syntax.value[CNFLogicConnective.OR] + ' '
+    #     cnf_formula = cnf_formula.replace(symbol_pattern, new_symbol)
 
-        # Translate NOT operators (this is more complex because
-        # the symbol may be part of a feature's name)
-        if cnf_notation == CNFNotation.TEXTUAL:
-            symbol_pattern = cnf_notation.value[LogicOperator.NOT] + ' '
-            new_symbol = cnf_output_syntax.value[LogicOperator.NOT]
-            cnf_formula = cnf_formula.replace(symbol_pattern, new_symbol)
-        elif cnf_output_syntax == CNFNotation.TEXTUAL:
-            symbol_pattern = ' ' + cnf_notation.value[LogicOperator.NOT]
-            new_symbol = ' ' + cnf_output_syntax.value[LogicOperator.NOT] + ' '
-            cnf_formula = cnf_formula.replace(symbol_pattern, new_symbol)
+    #     # Translate NOT operators (this is more complex because
+    #     # the symbol may be part of a feature's name)
+    #     if cnf_notation == TextCNFNotation.TEXTUAL:
+    #         symbol_pattern = cnf_notation.value[CNFLogicConnective.NOT] + ' '
+    #         new_symbol = cnf_output_syntax.value[CNFLogicConnective.NOT]
+    #         cnf_formula = cnf_formula.replace(symbol_pattern, new_symbol)
+    #     elif cnf_output_syntax == TextCNFNotation.TEXTUAL:
+    #         symbol_pattern = ' ' + cnf_notation.value[CNFLogicConnective.NOT]
+    #         new_symbol = ' ' + cnf_output_syntax.value[CNFLogicConnective.NOT] + ' '
+    #         cnf_formula = cnf_formula.replace(symbol_pattern, new_symbol)
 
-            symbol_pattern = '(' + cnf_notation.value[LogicOperator.NOT]
-            new_symbol = '(' + cnf_output_syntax.value[LogicOperator.NOT] + ' '
-            cnf_formula = cnf_formula.replace(symbol_pattern, new_symbol)
-        else:
-            symbol_pattern = ' ' + cnf_notation.value[LogicOperator.NOT]
-            new_symbol = ' ' + cnf_output_syntax.value[LogicOperator.NOT]
-            cnf_formula = cnf_formula.replace(symbol_pattern, new_symbol)
+    #         symbol_pattern = '(' + cnf_notation.value[CNFLogicConnective.NOT]
+    #         new_symbol = '(' + cnf_output_syntax.value[CNFLogicConnective.NOT] + ' '
+    #         cnf_formula = cnf_formula.replace(symbol_pattern, new_symbol)
+    #     else:
+    #         symbol_pattern = ' ' + cnf_notation.value[CNFLogicConnective.NOT]
+    #         new_symbol = ' ' + cnf_output_syntax.value[CNFLogicConnective.NOT]
+    #         cnf_formula = cnf_formula.replace(symbol_pattern, new_symbol)
 
-            symbol_pattern = '(' + cnf_notation.value[LogicOperator.NOT]
-            new_symbol = '(' + cnf_output_syntax.value[LogicOperator.NOT]
-            cnf_formula = cnf_formula.replace(symbol_pattern, new_symbol)
-        return cnf_formula
+    #         symbol_pattern = '(' + cnf_notation.value[CNFLogicConnective.NOT]
+    #         new_symbol = '(' + cnf_output_syntax.value[CNFLogicConnective.NOT]
+    #         cnf_formula = cnf_formula.replace(symbol_pattern, new_symbol)
+    #     return cnf_formula

--- a/famapy/metamodels/pysat_metamodel/transformations/fm_to_pysat.py
+++ b/famapy/metamodels/pysat_metamodel/transformations/fm_to_pysat.py
@@ -1,7 +1,8 @@
 import itertools
+from typing import Any
 
 from famapy.core.transformations import ModelToModel
-from famapy.metamodels.fm_metamodel.models.feature_model import (  # pylint: disable=import-error
+from famapy.metamodels.fm_metamodel.models.feature_model import (
     FeatureModel,
     Constraint,
     Feature,
@@ -145,7 +146,7 @@ class FmToPysat(ModelToModel):
                         self.r_cnf.append(cnf)
 
     def add_constraint(self, ctc: Constraint) -> None:
-        def transform_constraints(term):
+        def transform_constraints(term: Any) -> Constraint:
             if term.startswith('-'):
                 return -self.destination_model.variables.get(term[1:])
 

--- a/famapy/metamodels/pysat_metamodel/transformations/fm_to_pysat.py
+++ b/famapy/metamodels/pysat_metamodel/transformations/fm_to_pysat.py
@@ -24,8 +24,8 @@ class FmToPysat(ModelToModel):
         self.source_model = source_model
         self.counter = 1
         self.destination_model = PySATModel()
-        self.r_cnf = self.destination_model.r_cnf
-        self.ctc_cnf = self.destination_model.ctc_cnf
+        #self.r_cnf = self.destination_model.r_cnf
+        #self.ctc_cnf = self.destination_model.ctc_cnf
 
     def add_feature(self, feature: Feature) -> None:
         if feature.name not in self.destination_model.variables.keys():
@@ -34,16 +34,17 @@ class FmToPysat(ModelToModel):
             self.counter += 1
 
     def add_root(self, feature: Feature) -> None:
-        self.r_cnf.append([self.destination_model.variables.get(feature.name)])
+        #self.r_cnf.append([self.destination_model.variables.get(feature.name)])
+        self.destination_model.add_clause([self.destination_model.variables.get(feature.name)])
 
     def add_relation(self, relation: Relation) -> None:  # noqa: MC0001
         if relation.is_mandatory():
-            self.r_cnf.append([
+            self.destination_model.add_clause([
                 -1 *
                 self.destination_model.variables.get(relation.parent.name),
                 self.destination_model.variables.get(relation.children[0].name)
             ])
-            self.r_cnf.append([
+            self.destination_model.add_clause([
                 -1 *
                 self.destination_model.variables.get(
                     relation.children[0].name),
@@ -51,7 +52,7 @@ class FmToPysat(ModelToModel):
             ])
 
         elif relation.is_optional():
-            self.r_cnf.append([
+            self.destination_model.add_clause([
                 -1 *
                 self.destination_model.variables.get(
                     relation.children[0].name),
@@ -67,10 +68,10 @@ class FmToPysat(ModelToModel):
             for child in relation.children:
                 alt_cnf.append(
                     self.destination_model.variables.get(child.name))
-            self.r_cnf.append(alt_cnf)
+            self.destination_model.add_clause(alt_cnf)
 
             for child in relation.children:
-                self.r_cnf.append([
+                self.destination_model.add_clause([
                     -1 * self.destination_model.variables.get(child.name),
                     self.destination_model.variables.get(relation.parent.name)
                 ])
@@ -86,12 +87,12 @@ class FmToPysat(ModelToModel):
             for child in relation.children:
                 alt_cnf.append(
                     self.destination_model.variables.get(child.name))
-            self.r_cnf.append(alt_cnf)
+            self.destination_model.add_clause(alt_cnf)
 
             for i in range(len(relation.children)):
                 for j in range(i + 1, len(relation.children)):
                     if i != j:
-                        self.r_cnf.append([
+                        self.destination_model.add_clause([
                             -1 *
                             self.destination_model.variables.get(
                                 relation.children[i].name),
@@ -99,7 +100,7 @@ class FmToPysat(ModelToModel):
                             self.destination_model.variables.get(
                                 relation.children[j].name)
                         ])
-                self.r_cnf.append([
+                self.destination_model.add_clause([
                     -1 *
                     self.destination_model.variables.get(
                         relation.children[i].name),
@@ -128,7 +129,7 @@ class FmToPysat(ModelToModel):
                             else:
                                 cnf.append(
                                     self.destination_model.variables.get(feat.name))
-                        self.r_cnf.append(cnf)
+                        self.destination_model.add_clause(cnf)
                 else:
                     # This first for loop is to combine when the parent is not
                     # and the childs led to a 1-pathself which is actually
@@ -143,10 +144,10 @@ class FmToPysat(ModelToModel):
                             else:
                                 cnf.append(
                                     self.destination_model.variables.get(feat.name))
-                        self.r_cnf.append(cnf)
+                        self.destination_model.add_clause(cnf)
 
     def add_constraint(self, ctc: Constraint) -> None:
-        def transform_constraints(term: Any) -> Constraint:
+        def get_term_variable(term: Any) -> int:
             if term.startswith('-'):
                 return -self.destination_model.variables.get(term[1:])
 
@@ -154,8 +155,8 @@ class FmToPysat(ModelToModel):
 
         clauses = ctc.ast.get_clauses()
         for clause in clauses:
-            constraints = list(map(transform_constraints, clause))
-            self.r_cnf.append(constraints)
+            clause_variables = list(map(get_term_variable, clause))
+            self.destination_model.add_clause(clause_variables)
 
     def transform(self) -> PySATModel:
         for feature in self.source_model.get_features():

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="famapy-sat",
-    version="0.5.1",
+    version="0.6.0",
     author="Víctor Ramírez de la Corte",
     author_email="me@virako.es",
     description="famapy-sat is a plugin to FaMaPy module",
@@ -22,10 +22,20 @@ setuptools.setup(
     ],
     python_requires='>=3.9',
     install_requires=[
-        'famapy>=0.5.0',
+        'famapy>=0.6.1',
+        'famapy-fm>=0.6.0',
         'python-sat>=0.1.7.dev6'
     ],
+    extras_require={
+        'dev': [
+            'pytest',
+            'pytest-mock',
+            'prospector',
+            'mypy',
+            'coverage',
+        ]
+    },
     dependency_links=[
-        'famapy>=0.5.0'
+        'famapy>=0.6.1'
     ]
 )


### PR DESCRIPTION
This PR solves issue #35 

- Refactor PySAT model shouldn't split the clauses.
- Reimplement false-optional features operation. Now it passes all tests from old FAMA test suite, but it still fails for some real world feature models.
- Refactor Textual CNF model as an independent module inside `models` instead of being part of the reader module.

Current status of analysis operations in PySAT:
- [x] **Valid:**  pass all tests in Benchmark.
- [x] **Core features:** pass all tests in Benchmark.
- [x] **Dead features:** pass all tests in Benchmark.
- [x] **False-optional features:** pass all tests in Benchmark.
- [ ] **Error detection:** fail 2 tests (this operation needs to be reimplemented because now it uses splitted clauses in PySAT model).
- [ ] **Error diagnosis:** tests needed.
- [ ] **Filter:** tests needed.
- [ ] **Products:** tests needed.
- [x] **Products number:** pass all tests in Benchmark.
- [ ] **Valid product:** tests needed.
- [ ] **Valid configuration:** tests needed.
- [ ] **Atomic sets:** operation to be implemented.

@jagalindo  Do not merge this PR until all operations are tested in [Benchmark](https://github.com/diverso-lab/benchmarking).